### PR TITLE
Fix podspec no found

### DIFF
--- a/react-native-turbo-mock-location-detector.podspec
+++ b/react-native-turbo-mock-location-detector.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.authors      = package["author"]
 
   s.platforms    = { :ios => "12.4" }
-  s.source       = { :git => "https://github.com/jpudysz/react-native-mock-location-detector.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/jpudysz/react-native-turbo-mock-location-detector.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm}"
 


### PR DESCRIPTION
File name changed and source git


When run pod install

No podspec found for 'react-native-turbo-mock-localtion-detector' in '../node_modules/react-native-turbo-mock.......

:)