### PR TITLE
fix: Missing override on location listener

### DIFF
--- a/android/src/main/java/com/reactnativemocklocationdetector/MockLocationRequest.kt
+++ b/android/src/main/java/com/reactnativemocklocationdetector/MockLocationRequest.kt
@@ -41,7 +41,13 @@ class MockLocationRequest(
             }
         }
 
+        // The methods below should be override to work properly on Android R and below, to understand better, read the official documentation https://developer.android.com/reference/android/location/LocationListener
+
         override fun onStatusChanged(provider: String?, status: Int, extras: Bundle?) {}
+
+        override fun onProviderEnabled(provider: String) {}
+
+        override fun onProviderDisabled(provider: String) {}
     }
 
     @SuppressLint("MissingPermission")


### PR DESCRIPTION
## Description

We are facing the issue `abstract method "void android.location.LocationListener.onProviderDisabled(java.lang.String)"` specifically on devices with Android 10 (API 29 - R) or below. Reading the [official documentation about LocationListener](https://developer.android.com/reference/android/location/LocationListener) is described that the methods bellow should be override to work properly on Android R or below:
- [`onProviderDisabled`](https://developer.android.com/reference/android/location/LocationListener#onProviderDisabled(java.lang.String))
- [`onProviderEnabled`](https://developer.android.com/reference/android/location/LocationListener#onProviderEnabled(java.lang.String))