### PR TITLE
Update README with Expo DevClient rebuild note

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ cd ios && pod install
 ## Expo
 Works with no additional config
 
+If you are using the Expo DevClient for testing your app, then you need to rebuild it in order to make this library work.
+
 ## Prerequisites
 
 1. Use eg. [react-native-permissions](https://github.com/zoontek/react-native-permissions) to ask for location permission


### PR DESCRIPTION
Added note about rebuilding Expo DevClient for library usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README (Expo section) to clarify that when testing with Expo Dev Client, you must rebuild the app for the library to function. This helps avoid setup confusion, ensures accurate testing results, and improves onboarding. Existing projects may need a rebuild to validate integration. No functional or runtime behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->